### PR TITLE
Update webui.yml to force git to use HTTPS

### DIFF
--- a/roles/minemeld/tasks/webui.yml
+++ b/roles/minemeld/tasks/webui.yml
@@ -5,7 +5,7 @@
     clone: yes
     dest: "{{webui_repo_directory}}"
     version: "{{minemeld_version}}"
-- name: git configurating
+- name: reconfiguring git to use https
   command: git config --global url."https://github.com".insteadOf git@github.com
 - name: nodeenv
   pip: name=nodeenv

--- a/roles/minemeld/tasks/webui.yml
+++ b/roles/minemeld/tasks/webui.yml
@@ -5,7 +5,8 @@
     clone: yes
     dest: "{{webui_repo_directory}}"
     version: "{{minemeld_version}}"
-
+- name: git configurating
+  command: git config --global url."https://github.com".insteadOf git@github.com
 - name: nodeenv
   pip: name=nodeenv
 - name: minemeld nodeenv


### PR DESCRIPTION
Force git to use HTTPS instead of SSH because HTTPS is most likely to be allowed by a firewall/policy in hardened environment and [it's recommended by GitHub](https://help.github.com/articles/which-remote-url-should-i-use/#cloning-with-https-urls-recommended).