### PR TITLE
fixed a typo and updated to remove items deprecated as of ansible 2.4

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -2,7 +2,6 @@
   hosts: 127.0.0.1
   connection: local
   become: true
-  become_method: sudo
 
   vars:
     minemeld_version: develop
@@ -13,7 +12,7 @@
   # remove comment to set custom repositories
   # core_repo: "https://github.com/jtschichold/minemeld-core.git"
   # prototype_repo: "https://github.com/jtschichold/minemeld-node-prototypes.git"
-  # webui_repo: "https://github/jtschichold/minemeld-webui.git"
+  # webui_repo: "https://github.com/jtschichold/minemeld-webui.git"
 
   roles:
   - infrastructure

--- a/roles/infrastructure/tasks/main.yml
+++ b/roles/infrastructure/tasks/main.yml
@@ -12,7 +12,7 @@
 
 # include distribution tasks
 - name: include task based on distribution
-  include: "roles/infrastructure/tasks/{{infrastructure_include}}.yml"
+  include_tasks: "roles/infrastructure/tasks/{{infrastructure_include}}.yml"
   when: infrastructure_include is defined
 
 # install required services

--- a/roles/minemeld/handlers/main.yml
+++ b/roles/minemeld/handlers/main.yml
@@ -2,7 +2,6 @@
   command: "{{ venv_directory }}/bin/python setup.py develop"
   args:
     chdir: "{{ engine_directory }}/core"
-  sudo: no
 - name: restart collectd
   service: name=collectd state=restarted
 - name: stop rabbitmq-server

--- a/roles/minemeld/tasks/core.yml
+++ b/roles/minemeld/tasks/core.yml
@@ -32,9 +32,7 @@
 - name: create constraints file
   shell: "{{venv_directory}}/bin/pip freeze | grep -v minemeld-core > {{library_directory}}/constraints.txt"
 - name: create config file
-  command: "touch {{certs_directory}}/cacert-merge-config.yml"
-  args:
-    creates: "{{certs_directory}}/cacert-merge-config.yml"
+  file: path="{{certs_directory}}/cacert-merge-config.yml" state=touch owner=minemeld group=minemeld mode="{{file_permissions}}"
 - name: create CA bundle
   shell: "{{venv_directory}}/bin/mm-cacert-merge --config {{certs_directory}}/cacert-merge-config.yml --dst {{certs_directory}}/bundle.crt {{local_ca_directory}}"
   args:

--- a/roles/minemeld/tasks/main.yml
+++ b/roles/minemeld/tasks/main.yml
@@ -7,13 +7,13 @@
 
 # include distribution tasks
 - name: include pre-task based on distribution
-  include: "roles/minemeld/tasks/{{distribution_pre_task}}.yml"
+  include_tasks: "roles/minemeld/tasks/{{distribution_pre_task}}.yml"
   when: distribution_pre_task is defined
 
-- include: structure.yml
-- include: prototypes.yml
-- include: core.yml
-- include: webui.yml
+- import_tasks: structure.yml
+- import_tasks: prototypes.yml
+- import_tasks: core.yml
+- import_tasks: webui.yml
 
 # set permissions after install
 - name: minemeld directory permissions
@@ -21,7 +21,7 @@
 
 # include distribution tasks
 - name: include post-task based on distribution
-  include: "roles/minemeld/tasks/{{distribution_post_task}}.yml"
+  include_tasks: "roles/minemeld/tasks/{{distribution_post_task}}.yml"
   when: distribution_post_task is defined
 
 - debug: msg="Remember to add your user to the minemeld group"


### PR DESCRIPTION
Hey Luigi!

Just fixing some issues I found when running this ansible playbook. In particular a typo in the local.yml file for the file paths as well as some deprecated syntax as of ansible 2.4.1.
source: https://github.com/ansible/ansible/blob/stable-2.4/CHANGELOG.md#2.4

NOTE: retargetted to develop branch.

Thanks,
Nasir