### PR TITLE
Fix lodash._reinterpolate module missing

### DIFF
--- a/roles/minemeld/tasks/webui.yml
+++ b/roles/minemeld/tasks/webui.yml
@@ -18,6 +18,14 @@
     NODE_PATH: "{{www_venv_directory}}/lib/node_modules"
     NPM_CONFIG_PREFIX: "{{www_venv_directory}}"
     npm_config_prefix: "{{www_venv_directory}}"
+- name: npm configuration
+  command: npm install --save lodash._reinterpolate chdir="{{webui_repo_directory}}"
+  environment:
+    NODE_VIRTUAL_ENV: "{{www_venv_directory}}"
+    PATH: "{{www_venv_directory}}/lib/node_modules/.bin:{{www_venv_directory}}/bin:{{webui_repo_directory}}/node_modules/.bin:{{ ansible_env.PATH }}"
+    NODE_PATH: "{{www_venv_directory}}/lib/node_modules"
+    NPM_CONFIG_PREFIX: "{{www_venv_directory}}"
+    npm_config_prefix: "{{www_venv_directory}}"
 - name: bower install
   command: bower install --allow-root chdir="{{webui_repo_directory}}"
   environment:


### PR DESCRIPTION
On `gulp build` task, `lodash._reinterpolate` module is missing and then leads to run-time error. 

According to [lokeshjain2008](http://lokeshjain2008.github.io/2015/05/12/Error-Cannot-find-module-'lodash._reinterpolate'-in-npm.html), this problem can be fixed with  `npm install --save lodash._reinterpolate` to include the package inside of the dependencies section on `package.json`.