### PR TITLE
Fixes #35

### DIFF
--- a/roles/minemeld/tasks/core.yml
+++ b/roles/minemeld/tasks/core.yml
@@ -13,6 +13,10 @@
   command: virtualenv "{{venv_directory}}" -p python2.7 creates="{{venv_directory}}"
 - name: virtualenv permissions
   file: path="{{venv_directory}}" state=directory recurse=yes owner=minemeld group=minemeld mode="{{file_permissions}}"
+- name: downgrade pip
+  pip:
+    virtualenv: "{{venv_directory}}"
+    name: "pip<10.0"
 - name: requirements
   pip:
     virtualenv: "{{venv_directory}}"


### PR DESCRIPTION
- This is temporary workaround patch
- This issue is caused because pip version
- So far minemeld requires 'pip.utils.egg_link_path'
- But the function has no longer available on pip 10
- Therefore downgrade pip version to less then 10

Signed-off-by: Satoshi KOBAYASHI <satoshi-k@iij.ad.jp>