### PR TITLE
Added python-pip and virtualenv

### DIFF
--- a/roles/minemeld/vars/Ubuntu-18.04.yml
+++ b/roles/minemeld/vars/Ubuntu-18.04.yml
@@ -8,5 +8,7 @@ structure_packages:
   - libxslt1-dev
   - libc-ares-dev
   - libsnappy-dev
+  - python-pip
+  - virtualenv
 
 distribution_post_task: Ubuntu-16.04-post


### PR DESCRIPTION
I added python-pip and virtualenv to the to be installed packages for Ubuntu 18.04. While running the ansible playbook remote through ssh,the task to create a virtualenv failed due to the absence of setuptools. Installing python-pip and virtualenv  on the target machine solved the issue. This allows you to run an image build process from your CI/CD pipeline instead on the spot every time (cattle vs. pets) and thus supports the creation of an immutable image.