### PR TITLE
Add missing dependencies

### DIFF
--- a/roles/minemeld/vars/CentOS-7.yml
+++ b/roles/minemeld/vars/CentOS-7.yml
@@ -10,7 +10,9 @@ structure_packages:
   - libxslt-devel
   - c-ares-devel
   - snappy-devel
+  - python-devel
+  - Cython
 
 distribution_post_task: CentOS-7-post
 
-python_executable: /usr/local/bin/python2.7
+#python_executable: /usr/local/bin/python2.7

--- a/roles/minemeld/vars/RedHat-7.yml
+++ b/roles/minemeld/vars/RedHat-7.yml
@@ -10,6 +10,8 @@ structure_packages:
   - libxslt-devel
   - c-ares-devel
   - snappy-devel
+  - python-devel
+  - Cython
 
 distribution_post_task: RedHat-7-post
 


### PR DESCRIPTION
## Description

This changes add python-devel (needed for building any native python module) and Cython (needed for  building gdns extensions of minemeld engine) to the list of dependencies of redhat-based distributions (RedHat and CentOS)

## Motivation and Context

Those dependencies were missing

## Types of changes

- Bug fix (non-breaking change which fixes an issue)